### PR TITLE
fix: 아이템 구매 api 내 보유 아이템 수량 검증 로직 추가

### DIFF
--- a/src/main/java/com/seemonkey/bananajump/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/seemonkey/bananajump/item/service/ItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.seemonkey.bananajump.item.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -64,6 +65,15 @@ public class ItemServiceImpl implements ItemService {
 		Profile profile = profileRepository.findByMember_MemberId(memberId);
 		Item item = itemRepository.findById(itemId)
 			.orElseThrow(() -> new CustomException(ErrorType.ITEM_NOT_FOUND));
+
+		// item 개수 체크
+		int currentQty = Optional.ofNullable(
+			inventoryRepository.findQuantity(memberId, item.getId())
+		).orElse(0);
+
+		// 상한 체크: current + 구매수량 > 50이면 에러
+		if (currentQty + quantity > DEFAULT_MAX_LIMIT)
+			throw new CustomException(ErrorType.ITEM_MAX_LIMIT);
 
 		// 전체 금액 계산 (현재 quantity 는 고정 1)
 		Long totalCost = item.getCost() * quantity;


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #

### 💡 작업내용
아이템 구매 api 내 최대 보유 수량 검증(50개) 하는 로직이 빠져있어 추가합니다.

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
