### PR TITLE
feat: 피드백 노션 데이터베이스에 저장 기능 추가

### DIFF
--- a/src/main/java/com/seemonkey/bananajump/BananajumpApplication.java
+++ b/src/main/java/com/seemonkey/bananajump/BananajumpApplication.java
@@ -1,12 +1,20 @@
 package com.seemonkey.bananajump;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 public class BananajumpApplication {
+
+	@PostConstruct
+	public void setTimeZone() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(BananajumpApplication.class, args);

--- a/src/main/java/com/seemonkey/bananajump/common/exception/ErrorType.java
+++ b/src/main/java/com/seemonkey/bananajump/common/exception/ErrorType.java
@@ -63,6 +63,7 @@ public enum ErrorType {
 	// [Feedback / 피드백 관련]
 	// ===============================
 	DISCORD_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DISCORD-001", "디스코드 전송 중 오류가 발생했습니다."),
+	NOTION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NOTION-001", "노션 전송 중 오류가 발생했습니다."),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/seemonkey/bananajump/feedback/client/DiscordClient.java
+++ b/src/main/java/com/seemonkey/bananajump/feedback/client/DiscordClient.java
@@ -1,0 +1,46 @@
+package com.seemonkey.bananajump.feedback.client;
+
+import com.seemonkey.bananajump.common.exception.CustomException;
+import com.seemonkey.bananajump.common.exception.ErrorType;
+import com.seemonkey.bananajump.feedback.config.DiscordConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.http.HttpMethod.POST;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordClient {
+
+    private final DiscordConfig discordConfig;
+
+    public void sendMessage(Map<String, Object> payload) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf("application/json; charset=UTF-8"));
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+
+        ResponseEntity<String> response;
+        try {
+            response = new RestTemplate().exchange(
+                    discordConfig.getWebhookUrl(),
+                    POST,
+                    entity,
+                    String.class
+            );
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.DISCORD_SEND_FAILED);
+        }
+
+        Optional.ofNullable(response)
+                .filter(r -> r.getStatusCode().is2xxSuccessful())
+                .orElseThrow(() -> new CustomException(ErrorType.DISCORD_SEND_FAILED));
+    }
+}

--- a/src/main/java/com/seemonkey/bananajump/feedback/client/NotionClient.java
+++ b/src/main/java/com/seemonkey/bananajump/feedback/client/NotionClient.java
@@ -1,0 +1,60 @@
+package com.seemonkey.bananajump.feedback.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seemonkey.bananajump.common.exception.CustomException;
+import com.seemonkey.bananajump.common.exception.ErrorType;
+import com.seemonkey.bananajump.feedback.config.NotionConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class NotionClient {
+
+    private final NotionConfig notionConfig;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public void saveFeedback(Long memberId, String content, String createdAt) {
+        Map<String, Object> parent = Map.of("database_id", notionConfig.getDatabaseId());
+        Map<String, Object> props = new HashMap<>();
+
+        props.put("memberID", Map.of("title", new Object[]{
+                Map.of("text", Map.of("content", String.valueOf(memberId)))
+        }));
+        props.put("Content", Map.of("rich_text", new Object[]{Map.of("text", Map.of("content", content))}));
+        props.put("Date", Map.of("date", Map.of("start", createdAt)));
+
+        Map<String, Object> body = Map.of("parent", parent, "properties", props);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(notionConfig.getSecretKey());
+        headers.set("Notion-Version", "2022-06-28");
+
+        ResponseEntity<String> response;
+        try {
+            HttpEntity<String> request = new HttpEntity<>(mapper.writeValueAsString(body), headers);
+            response = new RestTemplate().postForEntity(
+                    notionConfig.getApiUrl() + "/pages",
+                    request,
+                    String.class
+            );
+        } catch (Exception e) {
+            throw new CustomException(ErrorType.NOTION_SEND_FAILED);
+        }
+
+        Optional.ofNullable(response)
+                .filter(r -> r.getStatusCode().is2xxSuccessful())
+                .orElseThrow(() -> new CustomException(ErrorType.NOTION_SEND_FAILED));
+    }
+}
+

--- a/src/main/java/com/seemonkey/bananajump/feedback/config/NotionConfig.java
+++ b/src/main/java/com/seemonkey/bananajump/feedback/config/NotionConfig.java
@@ -1,0 +1,20 @@
+package com.seemonkey.bananajump.feedback.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class NotionConfig {
+
+    @Value("${notion.api.url}")
+    private String apiUrl;
+
+    @Value("${notion.api.key}")
+    private String secretKey;
+
+    @Value("${notion.database.id}")
+    private String databaseId;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,10 @@ bananajump:
 
 discord:
   webhook-url: ${WEBHOOK_URL}
+
+notion:
+  api:
+    url: ${NOTION_API_URL}
+    key: ${NOTION_API_KEY}
+  database:
+    id: ${NOTION_DB_ID}


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #

### 💡 작업내용
- 피드백 노션에 저장하는 기능 개발했습니다.
- 일단 memberId는 1로 고정했습니다. 이후 토큰에서 꺼내는 로직 추가 예정입니다.
- 기존 Discord 로직이 더러워서 DiscordClient로 따로빼서 Service를 깔끔하게 변경했습니다.
- 서버 시간 한국에 맞추기 위해서 Main함수에 PostConstruct 추가했습니다.

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
